### PR TITLE
GDNet and README fixes

### DIFF
--- a/detectors/GDNet/README.md
+++ b/detectors/GDNet/README.md
@@ -62,7 +62,8 @@ docker run --rm --gpus all \
 -v INPUT_DIR:/detector/input \
 -v OUTPUT_DIR:/detector/output \
 -v GT_DIR:/detector/ground_truth \
-gdnet
+gdnet \
+--ground_truth_dir=/detector/ground_truth
 ```
 
 To run the model on CPU instead of GPU, omit the `--gpus all` flag.

--- a/detectors/GDNet/network_runner.py
+++ b/detectors/GDNet/network_runner.py
@@ -60,12 +60,12 @@ class NetworkRunner(NetworkRunnerBase):
             if self.calculate_secondary:
                 f1 = f1.data.squeeze(0).cpu()
                 f2 = f2.data.squeeze(0).cpu()
-                f1 = np.array(transforms.Resize(size[::-1])(self.to_pil(f1)))
-                f2 = np.array(transforms.Resize(size[::-1])(self.to_pil(f2)))
+                f1 = np.array(transforms.Resize(size)(self.to_pil(f1)))
+                f2 = np.array(transforms.Resize(size)(self.to_pil(f2)))
             else:
                 f1 = f2 = None
             f3 = f3.data.squeeze(0).cpu()
-            f3 = np.array(transforms.Resize(size[::-1])(self.to_pil(f3)))
+            f3 = np.array(transforms.Resize(size)(self.to_pil(f3)))
 
             if self.do_crf_refine:
                 if self.calculate_secondary:

--- a/detectors/TransLab/README.md
+++ b/detectors/TransLab/README.md
@@ -45,7 +45,8 @@ docker run --rm --gpus all \
 -v INPUT_DIR:/detector/input \
 -v OUTPUT_DIR:/detector/output \
 -v GT_DIR:/detector/ground_truth \
-translab
+translab \
+--ground_truth_dir=/detector/ground_truth
 ```
 
 To run the model on CPU instead of GPU, omit the `--gpus all` flag.


### PR DESCRIPTION
1. GDNet had incorrect output shape (height was taken for width and vice versa). 
2. Instructions in both GDNet and TransLab for running with metrics evaluation did not include `--ground_truth_dir` parameter, which is obligatory in this case. 